### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/breeznme/3900b3c0-18a2-46d4-bf3e-989f61c2bcc3/a9f0f08f-15a1-48c4-beea-d288a40746aa/_apis/work/boardbadge/2b527027-2ea0-422a-b384-a57c6a0b3d2c)](https://dev.azure.com/breeznme/3900b3c0-18a2-46d4-bf3e-989f61c2bcc3/_boards/board/t/a9f0f08f-15a1-48c4-beea-d288a40746aa/Microsoft.RequirementCategory)
 # blip-blah


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/breeznme/3900b3c0-18a2-46d4-bf3e-989f61c2bcc3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.